### PR TITLE
- updated version

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,7 @@ cypress-parallelize [options]
 ### Options
 
 - `--runner-amount=<Number>`: number of tests to split into each runner.
+- `--runner-annotation=<String>,`: custom runner annotaction how it should be used for the automation. (E.g. @custom-runner)
 - `--browser=<String>`: The browser to run tests in.
 - `--config-file=<String>`: The path to your Cypress config file.
 - `--spec=<String>`: path to the feature file to be handled by the runner.

--- a/bin/cypress-parallelize
+++ b/bin/cypress-parallelize
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 require = require('esm')(module /*, options*/);
-require('../src/cypress-parallelize').executeCommandXTimes(process.argv).then(r => console.log("Done the tests"));
+require('../src/cypress-parallelize').executeCommandXTimes(process.argv).then(r => console.log("Started the test runners"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gardosen/cypress-parallelize",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "cli command to parallelize cypress executions",
   "main": "src/index.js",
   "keywords": [

--- a/src/cypress-parallelize.js
+++ b/src/cypress-parallelize.js
@@ -16,25 +16,30 @@ export async function executeCommandXTimes(args) {
     cleanFeatureFiles(); //clean the found feature files from previous runner annotations (only works with the default annotation or if the custom annotation is the same as before
     assignTestRunnerAnnotation();
 
+    const runnerList = [];
+
     for (let i = 1; i <= scope.runnerAmountAssigned; i++) {
         try {
             const command = `npx cypress run --browser ${scope.options.browser} --config-file ${scope.options.configFile} --env allure=${scope.options.allure},allureResultsPath=allure-report-${scope.options.runnerAnnotation}${i},tags="${scope.options.tags} and ${scope.options.runnerAnnotation}${i}"${scope.options.specFile != null? " --spec "+scope.options.specFile:""}`;
             console.log(`Spawning console command [${command}]`)
             if( !scope.options.dryRun ) {
-                exec(command, (error, stdout, stderr) => {
-                    if (error) {
-                        console.error(`[Error][${i}]: ${error}`);
-                        return;
-                    }
-                    console.log(`[Info][${i}]: ${stdout}`);
-                });
-                //const {stdout} = execAsync(command);
-                //TODO Think about printout to log files
+                runnerList.push(execAsync(command));
             }
-
         } catch (error) {
             console.error(`Iteration ${i + 1} - Error: ${error.message}`);
         }
     }
 
+    Promise.all(runnerList)
+        .then((results) => {
+            if(scope.options.allure) {
+                console.log('All Runner have finished, handling allure-report now and removing skipped entries');
+                exec(`grep -rl '"status":"skipped"' ${process.cwd()}/allure-report-${scope.options.runnerAnnotation}-* | xargs rm -rf`);
+                console.log("Entries removed, merging all allure reports now to one single folder")
+                exec(`allure generate allure-report-${scope.options.runnerAnnotation}-*  -c -o "test-reports/${process.env.DOMAIN}/${process.env.TYPE}/$(date +"%Y-%m-%d--%H-%M-%S")" `);
+            }
+        })
+        .catch((error) => {
+            console.error(`[Error]]: ${error}`);
+        });
 }


### PR DESCRIPTION
- fixed an issue where the executor was not starting async execs, but parallel ones
- added a promise map to wait until all cypress executions are done, to handle the allure report generation
- added a custom path for the allure reports for each runner, so no conflict can happen between them when writing the results
- changed the console log for the starter promise to state the runners have started and not that all tests are done
- updated README.MD and added description for --runner-annotation